### PR TITLE
Fix a bug when deleteIcon is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.3] - 2019.05.31
+
+*    Fix a bug when deleteIcon is null
+
 ## [0.2.2] - 2019.05.25
 
 *    Fix the stuck when dragging

--- a/lib/dragablegridview_flutter.dart
+++ b/lib/dragablegridview_flutter.dart
@@ -250,13 +250,7 @@ class  DragAbleGridViewState <T extends DragAbleGridViewBin> extends State<DragA
                 new Offstage(
                   offstage: isHideDeleteIcon,
                   child: new GestureDetector(
-                    child: new Builder(builder: (BuildContext context){
-                      if(widget.deleteIcon!=null){
-                        return widget.deleteIcon;
-                      }else{
-                        return new Container();
-                      }
-                    }),
+                    child: widget.deleteIcon ?? Container(height: 0, width: 0),
                     onTap: () {
                       setState(() {
                         widget.itemBins[index].offstage=true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dragablegridview_flutter
 description: A dragable gridview,Long-pressed triggers draggable state,GridView reordering after release your finger
-version: 0.2.2
+version: 0.2.3
 author: baoolong <baoolong1987@gmail.com>
 homepage: https://github.com/baoolong/DragableGridview
 


### PR DESCRIPTION
作者你好，我修复了一个bug
当不传deleteIcon的时候，长摁元素会导致所有元素消失
应该是返回了一个没有限定大小的`Container()`导致的